### PR TITLE
Silence warning from minitest

### DIFF
--- a/test/event_sourced_record/calculator_test.rb
+++ b/test/event_sourced_record/calculator_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class EventSourcedRecord::CalculatorTest < MiniTest::Unit::TestCase
+class EventSourcedRecord::CalculatorTest < MiniTest::Test
   def setup
     @event = SubscriptionEvent.creation.create!(
       bottles_per_shipment: 1, bottles_purchased: 6, user_id: 12345

--- a/test/event_sourced_record/event_test.rb
+++ b/test/event_sourced_record/event_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class EventSourcedRecord::EventTest < MiniTest::Unit::TestCase
+class EventSourcedRecord::EventTest < MiniTest::Test
   def test_creation_auto_generates_uuid
     event = SubscriptionEvent.creation.new
     assert event.subscription_uuid


### PR DESCRIPTION
Without this I get a `MiniTest::Unit::TestCase is now Minitest::Test` warning when running the tests.
