### PR TITLE
Ensure events are readonly after they have been saved

### DIFF
--- a/event_sourced_record.gemspec
+++ b/event_sourced_record.gemspec
@@ -25,6 +25,7 @@ EventSourcedRecord uses Rails observers. If you are using Rails 4.0 or greater, 
   MESSAGE
 
   spec.add_dependency 'activemodel'
+  spec.add_dependency 'activerecord-immutable', '~> 0.0.3'
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"

--- a/lib/event_sourced_record/event.rb
+++ b/lib/event_sourced_record/event.rb
@@ -1,4 +1,8 @@
+require 'active_record/immutable'
+
 module EventSourcedRecord::Event
+  include ActiveRecord::Immutable
+
   def self.included(model)
     model.cattr_accessor :_event_type_configs
     model.extend ClassMethods

--- a/test/event_sourced_record/event_test.rb
+++ b/test/event_sourced_record/event_test.rb
@@ -109,4 +109,14 @@ class EventSourcedRecord::EventTest < MiniTest::Unit::TestCase
       event.event_type = 'change_settings'
     end
   end
+
+  def test_events_are_immutable
+    event = SubscriptionEvent.creation.create!(
+      bottles_per_shipment: 1, bottles_purchased: 6, user_id: 999
+    )
+
+    assert_raises(ActiveRecord::ReadOnlyRecord) do
+      event.touch
+    end
+  end
 end


### PR DESCRIPTION
This handles some cases, but unfortunately methods like `#delete` do not check this value.

I would be happy to add code that disables all of the dangerous methods as well, WDYT?
