### PR TITLE
Add `occurred_at` to generated event model?

### DIFF
--- a/lib/event_sourced_record/calculator.rb
+++ b/lib/event_sourced_record/calculator.rb
@@ -88,11 +88,19 @@ class EventSourcedRecord::Calculator
         conditions = {projection_name + '_id' => projection.id} if projection
       end
       conditions ? event_class.where(conditions).to_a : []
-    }.flatten.sort_by(&:created_at).reject { |evt|
+    }.flatten.sort_by{ |evt| occurrence_time(evt) }.reject { |evt|
       if last_event_time
-        evt.created_at > last_event_time
+        occurrence_time(evt) > last_event_time
       end
     }
+  end
+
+  def occurrence_time(event)
+    if event.respond_to?(:occurred_at) && event.occurred_at
+      event.occurred_at
+    else
+      event.created_at
+    end
   end
 
   def uuid_field

--- a/lib/event_sourced_record/event.rb
+++ b/lib/event_sourced_record/event.rb
@@ -9,6 +9,7 @@ module EventSourcedRecord::Event
     model.after_initialize :ensure_data
     model.after_initialize :ensure_projection_uuid
     model.after_initialize :lock_event_type
+    model.before_validation :ensure_occurred_at, on: :create
     model.validates :event_type, presence: true
     model.validate :validate_corrent_event_type
     model.validate :validate_by_event_type
@@ -54,6 +55,10 @@ module EventSourcedRecord::Event
 
   def lock_event_type
     @event_type_locked = true
+  end
+
+  def ensure_occurred_at
+    self.occurred_at = Time.now unless occurred_at
   end
 
   def method_missing(meth, *args, &block)

--- a/lib/generators/event_sourced_record/event_sourced_record_generator.rb
+++ b/lib/generators/event_sourced_record/event_sourced_record_generator.rb
@@ -13,7 +13,7 @@ class EventSourcedRecord::EventSourcedRecordGenerator < Rails::Generators::Named
   def create_event
     arguments = [
       "#{file_name}_uuid:string:index", "event_type:string", 
-      "data:text", "created_at:datetime"
+      "data:text", "created_at:datetime", "occurred_at:datetime"
     ].join(' ')
     generate "event_sourced_record:event", "#{file_name}_event #{arguments}"
   end

--- a/test/event_sourced_record/event_test.rb
+++ b/test/event_sourced_record/event_test.rb
@@ -119,4 +119,21 @@ class EventSourcedRecord::EventTest < MiniTest::Unit::TestCase
       event.touch
     end
   end
+
+  def test_occurred_at_is_set_if_not_specified
+    event = SubscriptionEvent.creation.create!(
+      bottles_per_shipment: 1, bottles_purchased: 6, user_id: 999
+    )
+
+    assert event.occurred_at
+  end
+
+  def test_occurred_at_can_be_specified
+    event = SubscriptionEvent.creation.new(
+      occurred_at: Time.new(2003, 1, 24, 11, 33), bottles_per_shipment: 1,
+      bottles_purchased: 6, user_id: 999
+    )
+
+    assert_equal(Time.new(2003, 1, 24, 11, 33), event.occurred_at)
+  end
 end

--- a/test/generators/event_generator_test.rb
+++ b/test/generators/event_generator_test.rb
@@ -16,6 +16,7 @@ class EventSourcedRecord::EventGeneratorTest < Rails::Generators::TestCase
       event_type:string
       data:text
       created_at:datetime
+      occurred_at:datetime
     )
   end
 
@@ -23,11 +24,13 @@ class EventSourcedRecord::EventGeneratorTest < Rails::Generators::TestCase
     ar_major_version = ActiveRecord::VERSION::MAJOR
     if ar_major_version >= 4
       assert @generate_calls['migration'].include?(
-        "create_subscription_events subscription_uuid:string:index event_type:string data:text created_at:datetime"
+        "create_subscription_events subscription_uuid:string:index event_type:string data:text created_at:datetime occurred_at:datetime"
       )
     else
       assert_migration("db/migrate/create_subscription_events.rb") do |contents|
         assert_match(/t.string :event_type/, contents)
+        assert_match(/t.datetime :created_at/, contents)
+        assert_match(/t.datetime :occurred_at/, contents)
       end
     end
   end

--- a/test/generators/event_sourced_record_generator_test.rb
+++ b/test/generators/event_sourced_record_generator_test.rb
@@ -20,7 +20,7 @@ class EventSourcedRecord::EventSourcedRecordGeneratorTest < Rails::Generators::T
 
   test "calls the event generator" do
     assert @generate_calls['event_sourced_record:event'].include?(
-      "shampoo_subscription_event shampoo_subscription_uuid:string:index event_type:string data:text created_at:datetime"
+      "shampoo_subscription_event shampoo_subscription_uuid:string:index event_type:string data:text created_at:datetime occurred_at:datetime"
     )
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -38,6 +38,7 @@ silence_stream(STDOUT) do
       t.string   "event_type"
       t.text     "data"
       t.datetime "created_at"
+      t.datetime "occurred_at"
     end
 
     create_table "subscriptions", force: true do |t|


### PR DESCRIPTION
Would you be interested in a PR to add `occurred_at` do the generated event model, defaulting to Time.now/created_at? I've definitely run into the case where I needed to 'backfill' events or add correction events at a specific time.
