### PR TITLE
Storage options for `data`

### DIFF
--- a/Getting_Started.md
+++ b/Getting_Started.md
@@ -66,6 +66,8 @@ You might never end up showing this model to end-users, but in fact it's the aut
     class SubscriptionEvent < ActiveRecord::Base
       include EventSourcedRecord::Event
 
+      serialize :data
+
       belongs_to :subscription, 
         foreign_key: 'subscription_uuid', primary_key: 'uuid'
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ The event model is an ActiveRecord model but it can act significantly different 
     class SubscriptionEvent < ActiveRecord::Base
       include EventSourcedRecord::Event
 
+      serialize :data
+
       belongs_to :subscription, 
         foreign_key: 'subscription_uuid', primary_key: 'uuid'
 
@@ -73,6 +75,11 @@ The easiest way to create these records is with the scopes that are automaticall
       bottles_per_shipment: 1, bottles_purchased: 6, user_id: current_user.id
     )
     
+The event attributes are stored in the `data` column, which by default is
+serialized to a text field. If you'd prefer to use e.g. JSONB with PostgreSQL
+9.4+, just remove the call to `serialize` and modify the migration to use your
+preferred type.
+
 ## Projection
 
 The projection is the ActiveRecord model that is generated deterministically with the data in the timestamped events combined with the logic in the calculator.  Projections shouldn't have any code for modifying themselves, as that will be done externally.  Accordingly, projections end up being fairly small classes:

--- a/lib/event_sourced_record/event.rb
+++ b/lib/event_sourced_record/event.rb
@@ -8,7 +8,6 @@ module EventSourcedRecord::Event
     model.validates :event_type, presence: true
     model.validate :validate_corrent_event_type
     model.validate :validate_by_event_type
-    model.serialize :data
   end
 
   def event_type

--- a/lib/generators/event_sourced_record/templates/event_model.rb
+++ b/lib/generators/event_sourced_record/templates/event_model.rb
@@ -2,6 +2,8 @@
 class <%= event_class_name %> < ActiveRecord::Base
   include EventSourcedRecord::Event
 
+  serialize :data
+
   belongs_to :<%= belongs_to_name %>,
     foreign_key: '<%= belongs_to_foreign_key %>', primary_key: 'uuid'
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -55,6 +55,8 @@ end
 class SubscriptionEvent < ActiveRecord::Base
   include EventSourcedRecord::Event
 
+  serialize :data
+
   event_type :creation do
     attributes :bottles_per_shipment, :bottles_purchased, :user_id
 


### PR DESCRIPTION
Currently the way the `data` attribute is stored is hard coded in EventSourcedRecord::Event.

What would you think about adding `serialize :data` to the generated model class instead? This would allow using e.g. jsonb with the latest versions of PG and Rails by removing that line and changing the generated migration.
