### PR TITLE
Calculator seems to be trying to find the wrong type of events

### DIFF
--- a/lib/event_sourced_record/calculator.rb
+++ b/lib/event_sourced_record/calculator.rb
@@ -1,10 +1,10 @@
 class EventSourcedRecord::Calculator
   def self.events(*event_symbols)
-    @@event_symbols = event_symbols
+    @event_symbols = event_symbols
   end
 
   def self.event_classes
-    @@event_symbols.map { |sym| 
+    @event_symbols.map { |sym|
       Module.const_get(sym.to_s.singularize.camelize)
     }
   end


### PR DESCRIPTION
So this is preliminary in that I don't have 100% of the details, but I figured I would post what I have now in case you can see what it is right away.

I've seen this several times in development, and now once in a staging environment (details below) so it's not due to rails autoload magic as I first suspected.

What I'm seeing is that sometimes the calculator seems to get confused about what events it should load. In the application below, both Site and UserSession are event_sourced_records. I create a Site, and for some reason the calculator seems to try to load the UserSessionEvents, attempting to join on a `site_id` column.

Any ideas? I'll continue to dig into it and update this issue with my findings.

```
irb(main):003:0> SiteEvent.creation.create! subdomain: 'helpnow', region_id: dk.id
   (28.5ms)  BEGIN
   (28.5ms)  BEGIN
  SQL (8.1ms)  INSERT INTO "site_events" ("data", "event_type", "site_uuid", "occurred_at", "created_at") VALUES ($1, $2, $3, $4, $5) RETURNING "id"  [["data", "{\"subdomain\":\"helpnow\",\"region_id\":1}"], ["event_type", "creation"], ["site_uuid", "4c6051ed-e700-49ea-b5f9-e4ed69a8f8dd"], ["occurred_at", "2015-02-13 15:03:25.334774"], ["created_at", "2015-02-13 15:03:25.335848"]]
  SQL (8.1ms)  INSERT INTO "site_events" ("data", "event_type", "site_uuid", "occurred_at", "created_at") VALUES ($1, $2, $3, $4, $5) RETURNING "id"  [["data", "{\"subdomain\":\"helpnow\",\"region_id\":1}"], ["event_type", "creation"], ["site_uuid", "4c6051ed-e700-49ea-b5f9-e4ed69a8f8dd"], ["occurred_at", "2015-02-13 15:03:25.334774"], ["created_at", "2015-02-13 15:03:25.335848"]]
  Site Load (2.4ms)  SELECT  "sites".* FROM "sites" WHERE "sites"."uuid" = NULL  ORDER BY "sites"."id" ASC LIMIT 1
  Site Load (2.4ms)  SELECT  "sites".* FROM "sites" WHERE "sites"."uuid" = NULL  ORDER BY "sites"."id" ASC LIMIT 1
  UserSessionEvent Load (5.7ms)  SELECT "user_session_events".* FROM "user_session_events" WHERE "user_session_events"."site_id" IS NULL
  UserSessionEvent Load (5.7ms)  SELECT "user_session_events".* FROM "user_session_events" WHERE "user_session_events"."site_id" IS NULL
PG::UndefinedColumn: ERROR:  column user_session_events.site_id does not exist
LINE 1: ...ession_events".* FROM "user_session_events" WHERE "user_sess...
                                                             ^
: SELECT "user_session_events".* FROM "user_session_events" WHERE "user_session_events"."site_id" IS NULL
PG::UndefinedColumn: ERROR:  column user_session_events.site_id does not exist
LINE 1: ...ession_events".* FROM "user_session_events" WHERE "user_sess...
                                                             ^
: SELECT "user_session_events".* FROM "user_session_events" WHERE "user_session_events"."site_id" IS NULL
   (0.5ms)  ROLLBACK
   (0.5ms)  ROLLBACK
ActiveRecord::StatementInvalid: PG::UndefinedColumn: ERROR:  column user_session_events.site_id does not exist
LINE 1: ...ession_events".* FROM "user_session_events" WHERE "user_sess...
                                                             ^
: SELECT "user_session_events".* FROM "user_session_events" WHERE "user_session_events"."site_id" IS NULL
        from /app/vendor/bundle/ruby/2.2.0/gems/activerecord-4.2.0/lib/active_record/connection_adapters/postgresql_adapter.rb:592:in `async_exec'
        from /app/vendor/bundle/ruby/2.2.0/gems/activerecord-4.2.0/lib/active_record/connection_adapters/postgresql_adapter.rb:592:in `block in exec_no_cache'
        from /app/vendor/bundle/ruby/2.2.0/gems/activerecord-4.2.0/lib/active_record/connection_adapters/abstract_adapter.rb:466:in `block in log'
        from /app/vendor/bundle/ruby/2.2.0/gems/activesupport-4.2.0/lib/active_support/notifications/instrumenter.rb:20:in `instrument'
        from /app/vendor/bundle/ruby/2.2.0/gems/activerecord-4.2.0/lib/active_record/connection_adapters/abstract_adapter.rb:460:in `log'
        from /app/vendor/bundle/ruby/2.2.0/gems/activerecord-4.2.0/lib/active_record/connection_adapters/postgresql_adapter.rb:592:in `exec_no_cache'
        from /app/vendor/bundle/ruby/2.2.0/gems/activerecord-4.2.0/lib/active_record/connection_adapters/postgresql_adapter.rb:584:in `execute_and_clear'
        from /app/vendor/bundle/ruby/2.2.0/gems/activerecord-4.2.0/lib/active_record/connection_adapters/postgresql/database_statements.rb:160:in `exec_query'
        from /app/vendor/bundle/ruby/2.2.0/gems/activerecord-4.2.0/lib/active_record/connection_adapters/abstract/database_statements.rb:336:in `select'
        from /app/vendor/bundle/ruby/2.2.0/gems/activerecord-4.2.0/lib/active_record/connection_adapters/abstract/database_statements.rb:32:in `select_all'
        from /app/vendor/bundle/ruby/2.2.0/gems/activerecord-4.2.0/lib/active_record/connection_adapters/abstract/query_cache.rb:70:in `select_all'
        from /app/vendor/bundle/ruby/2.2.0/gems/activerecord-4.2.0/lib/active_record/querying.rb:39:in `find_by_sql'
        from /app/vendor/bundle/ruby/2.2.0/gems/activerecord-4.2.0/lib/active_record/relation.rb:638:in `exec_queries'
        from /app/vendor/bundle/ruby/2.2.0/gems/activerecord-4.2.0/lib/active_record/relation.rb:514:in `load'
        from /app/vendor/bundle/ruby/2.2.0/gems/activerecord-4.2.0/lib/active_record/relation.rb:243:in `to_a'
        from /app/vendor/bundle/ruby/2.2.0/bundler/gems/event_sourced_record-ba65e4b118c8/lib/event_sourced_record/calculator.rb:90:in `block in sorted_events'
... 30 levels...
        from /app/vendor/bundle/ruby/2.2.0/gems/activerecord-4.2.0/lib/active_record/connection_adapters/abstract/database_statements.rb:213:in `transaction'
        from /app/vendor/bundle/ruby/2.2.0/gems/activerecord-4.2.0/lib/active_record/transactions.rb:220:in `transaction'
        from /app/vendor/bundle/ruby/2.2.0/gems/activerecord-4.2.0/lib/active_record/transactions.rb:344:in `with_transaction_returning_status'
        from /app/vendor/bundle/ruby/2.2.0/gems/activerecord-4.2.0/lib/active_record/transactions.rb:291:in `save!'
        from /app/vendor/bundle/ruby/2.2.0/gems/activerecord-4.2.0/lib/active_record/persistence.rb:51:in `create!'
        from /app/vendor/bundle/ruby/2.2.0/gems/activerecord-4.2.0/lib/active_record/relation.rb:151:in `block in create!'
        from /app/vendor/bundle/ruby/2.2.0/gems/activerecord-4.2.0/lib/active_record/relation.rb:302:in `scoping'
        from /app/vendor/bundle/ruby/2.2.0/gems/activerecord-4.2.0/lib/active_record/relation.rb:151:in `create!'
        from (irb):3
        from /app/vendor/bundle/ruby/2.2.0/gems/railties-4.2.0/lib/rails/commands/console.rb:110:in `start'
        from /app/vendor/bundle/ruby/2.2.0/gems/railties-4.2.0/lib/rails/commands/console.rb:9:in `start'
        from /app/vendor/bundle/ruby/2.2.0/gems/railties-4.2.0/lib/rails/commands/commands_tasks.rb:68:in `console'
        from /app/vendor/bundle/ruby/2.2.0/gems/railties-4.2.0/lib/rails/commands/commands_tasks.rb:39:in `run_command!'
        from /app/vendor/bundle/ruby/2.2.0/gems/railties-4.2.0/lib/rails/commands.rb:17:in `<top (required)>'
        from /app/bin/rails:8:in `require'
        from /app/bin/rails:8:in `<main>'irb(main):004:0>
```
