### PR TITLE
WIP - Add uuid in ar3 projection generated migration

### DIFF
--- a/lib/generators/event_sourced_record/templates/projection_migration.ar3.rb
+++ b/lib/generators/event_sourced_record/templates/projection_migration.ar3.rb
@@ -4,11 +4,13 @@ class <%= projection_migration_class_name %> < ActiveRecord::Migration
 <% attributes.each do |attribute| -%>
       t.<%= attribute.type %> :<%= attribute.name %><%= attribute.inject_options %>
 <% end -%>
+      t.string :uuid
       t.timestamps
     end
 <% attributes_with_index.each do |attribute| -%>
     add_index :<%= table_name %>, :<%= attribute.index_name %><%= attribute.inject_index_options %>
 <% end -%>
+    add_index :<%= table_name %>, :uuid, :unique => true
   end
 end
 

--- a/test/generators/projection_generator_test.rb
+++ b/test/generators/projection_generator_test.rb
@@ -30,7 +30,9 @@ class EventSourcedRecord::ProjectionGeneratorTest < Rails::Generators::TestCase
     else
       assert_migration("db/migrate/create_subscriptions.rb") do |contents|
         assert_match(/t.integer :user_id/, contents)
+        assert_match(/t.string :uuid/, contents)
         assert_match(/t.timestamps/, contents)
+        assert_match(/add_index :\w*, :uuid, :unique => true/, contents)
       end
     end
   end


### PR DESCRIPTION
Found that running the generator in Rails 3.2 does not add the `uuid` to the projection migration, so I fixed it.

I'm not sure this is mergeable yet - would like to have the test suite run both the test for 4.0+ and for 3.2, but I haven't just yet found a way to do that.

Also I'm thinking it would be nice to refactor the fix:
1. [ ] If the user passes a `uuid` option to when calling `rails generate event_sourced_record FooBar`, i think the migration will include the passed option as well as the one I've coded in.
2. [ ] Adding the `uuid` migration is coded in one method for 4.0+ and in a template for 3.2; it would be nice that there was one place to set default attributes to add to the migration.

Wanted to open a P.R. to start out, though, and start a conversation. Also for the refactors above, I haven't made much progress yet so if people have some guidance / ideas, please post.

cc @fhwang and @Trevoke 
